### PR TITLE
Keep error related functionality to Failure

### DIFF
--- a/src/Result/Failure.php
+++ b/src/Result/Failure.php
@@ -26,4 +26,17 @@ class Failure extends Result
     {
         parent::__construct(false, ...$errors);
     }
+    /**
+     * @return array
+     */
+    public function getErrors(): array
+    {
+        return $this->errors;
+    }
+
+    public function getFirstError() : Error
+    {
+        return $this->errors[0];
+
+    }
 }

--- a/src/Result/Result.php
+++ b/src/Result/Result.php
@@ -7,7 +7,7 @@ use Phypes\Error\Error;
 abstract class Result
 {
     private $valid;
-    private $errors = [];
+    protected $errors = [];
 
     public function __construct(bool $valid, Error... $errors)
     {
@@ -18,21 +18,5 @@ abstract class Result
     public function isValid() : bool
     {
         return $this->valid;
-    }
-
-    /**
-     * @return array
-     */
-    public function getErrors(): array
-    {
-        return $this->errors;
-    }
-
-    public function getFirstError() : ?Error
-    {
-        if (!$this->valid) {
-            return $this->errors[0];
-        }
-        return null;
     }
 }

--- a/tests/UnitTests/Rule/String/MaximumLengthTest.php
+++ b/tests/UnitTests/Rule/String/MaximumLengthTest.php
@@ -5,6 +5,7 @@ namespace Phypes\UnitTest\Rule\String;
 use Phypes\Error\Error;
 use Phypes\Error\RuleErrorCode;
 use Phypes\Result\Result;
+use Phypes\Result\Success;
 use Phypes\Rule\Rule;
 use Phypes\Rule\String\MaximumLength;
 use PHPUnit\Framework\TestCase;
@@ -87,16 +88,13 @@ class MaximumLengthTest extends TestCase
         $this->assertTrue($result->isValid());
     }
 
-    /**
-     * Success shouldn't return an Error instance
-     */
     public function testValidateSuccessError()
     {
         $text = 'Player';
         $rule = new MaximumLength(7);
         $result = $rule->validate($text);
 
-        $this->assertNull($result->getFirstError()) ;
+        $this->assertInstanceOf(Success::class, $result);
     }
 
     private function getFailedResult() : Result

--- a/tests/UnitTests/Rule/String/MinimumLengthTest.php
+++ b/tests/UnitTests/Rule/String/MinimumLengthTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\TestCase;
 use Phypes\Error\Error;
 use Phypes\Error\RuleErrorCode;
 use Phypes\Result\Result;
+use Phypes\Result\Success;
 use Phypes\Rule\Rule;
 use Phypes\Rule\String\MinimumLength;
 
@@ -96,7 +97,7 @@ class MinimumLengthTest extends TestCase
         $rule = new MinimumLength(5);
         $result = $rule->validate($text);
 
-        $this->assertNull($result->getFirstError()) ;
+        $this->assertInstanceOf(Success::class, $result) ;
     }
 
     private function getFailedResult() : Result

--- a/tests/UnitTests/Validator/EmailValidatorTest.php
+++ b/tests/UnitTests/Validator/EmailValidatorTest.php
@@ -4,6 +4,7 @@ namespace Phypes\UnitTest\Validator;
 
 use Phypes\Error\TypeErrorCode;
 use PHPUnit\Framework\TestCase;
+use Phypes\Result\Success;
 use Phypes\Validator\EmailValidator;
 use Phypes\Validator\Validator;
 
@@ -69,9 +70,9 @@ class EmailValidatorTest extends TestCase
      */
     public function testNoErrorOnValidEmail() : void
     {
-        $error = $this->validator->validate('2d@twodee.me')->getFirstError();
+        $result = $this->validator->validate('2d@twodee.me');
 
-        $this->assertNull($error);
+        self::assertInstanceOf(Success::class, $result);
     }
 
 }

--- a/tests/UnitTests/Validator/IPAddressValidatorTest.php
+++ b/tests/UnitTests/Validator/IPAddressValidatorTest.php
@@ -4,6 +4,7 @@ namespace Phypes\UnitTest\Validator;
 
 use PHPUnit\Framework\TestCase;
 use Phypes\Error\TypeErrorCode;
+use Phypes\Result\Success;
 use Phypes\Validator\IPAddressValidator;
 use Phypes\Validator\Validator;
 
@@ -66,8 +67,8 @@ class IPAddressValidatorTest extends TestCase
      */
     public function testErrorOnPass() : void
     {
-        $error = $this->validator->validate('192.168.0.0')->getFirstError();
-        $this->assertNull($error);
+        $result = $this->validator->validate('192.168.0.0');
+        $this->assertInstanceOf(Success::class, $result);
     }
 
     /**

--- a/tests/UnitTests/Validator/PasswordValidatorTest.php
+++ b/tests/UnitTests/Validator/PasswordValidatorTest.php
@@ -4,6 +4,7 @@ namespace Phypes\UnitTest\Validator;
 
 use PHPUnit\Framework\TestCase;
 use Phypes\Error\TypeErrorCode;
+use Phypes\Result\Success;
 use Phypes\Validator\PasswordValidator;
 use Phypes\Validator\Validator;
 
@@ -147,13 +148,13 @@ class PasswordValidatorTest extends TestCase
         $this->assertEquals($expectation, $code);
     }
     /**
-     * Expecting a null message on no error validation
+     * Expecting an instance of Success::class on success
      */
     public function testValidPasswordErrorOutput() : void
     {
-        $error = $this->validator->validate('easypasswordA!')->getFirstError();
+        $result = $this->validator->validate('easypasswordA!');
 
-        $this->assertNull($error);
+        $this->assertInstanceOf(Success::class, $result);
     }
 
     public function testMultipleValidationError() : void


### PR DESCRIPTION
Success has nothing to do with errors. Hence, only Failure instances can return errors, tests have been fixed to only work with Failure instances and check the instances of results to verify if they are successful or not.